### PR TITLE
Add repository xml file

### DIFF
--- a/sakaki-tools.xml
+++ b/sakaki-tools.xml
@@ -1,0 +1,11 @@
+<repositories encoding="unicode" version="1.1">
+  <repo priority="50" quality="experimental">
+    <name>sakaki-tools</name>
+    <description>Various utility ebuilds for Gentoo on EFI</description>
+    <owner>
+      <email>sakaki@deciban.com</email>
+      <name>sakaki</name>
+    </owner>
+    <source type="git">https://github.com/sakaki-/sakaki-tools.git</source>
+  </repo>
+</repositories>


### PR DESCRIPTION
Adds a repository definition xml file to easy repository installation via layman - see https://wiki.gentoo.org/wiki/Layman#Adding_custom_repositories

This one works for me, but feel free to make any changes.